### PR TITLE
Add flag to strip chr from sequences names

### DIFF
--- a/MALVA
+++ b/MALVA
@@ -26,6 +26,7 @@ Arguments:
      -c              maximum coverage for variant alleles (default:'"${DEFAULT_MAX_COV}"')
      -b              bloom filter size in GB (default:'"${DEFAULT_BF_SIZE}"')
      -m              max amount of RAM in GB - KMC parameter (default:'"${DEFAULT_MAX_MEM}"')
+     -p              strip \"chr\" from sequence names (dafault:false)
 
 Positional arguments:
      <reference>     reference file in FASTA format
@@ -44,8 +45,9 @@ samples=${DEFAULT_SAMPLES}
 maxcov=${DEFAULT_MAX_COV}
 bfsize=${DEFAULT_BF_SIZE}
 maxmem=${DEFAULT_MAX_MEM}
+strip_chr=""
 
-while getopts "k:r:e:f:s:c:b:m:h" flag; do
+while getopts "k:r:e:f:s:c:b:m:hp" flag; do
     case "${flag}" in
 	h) $(>&2 echo "${USAGE}")
 	   exit 0
@@ -66,6 +68,8 @@ while getopts "k:r:e:f:s:c:b:m:h" flag; do
 	   ;;
 	m) maxmem=${OPTARG}
 	   ;;
+  p) strip_chr="-p"
+     ;;
     esac
 done
 
@@ -94,7 +98,7 @@ else
 fi
 
 (>&2 echo "[${SCRIPT_NAME}] Running ${BIN_NAME}")
-${EXECUTABLE} -k ${k} -r ${refk} -e ${erate} -f ${freq} -s ${samples} -c ${maxcov} -b ${bfsize}  ${reference} ${vcf_file} ${kmc_out_prefix}
+${EXECUTABLE} ${strip_chr} -k ${k} -r ${refk} -e ${erate} -f ${freq} -s ${samples} -c ${maxcov} -b ${bfsize}  ${reference} ${vcf_file} ${kmc_out_prefix}
 
 (>&2 echo "[${SCRIPT_NAME}] Cleaning up")
 rm -rf ${kmc_tmp_dir}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Arguments:
     -f, --freq-key                    a priori frequency key in the INFO column of the input VCF (default:AF)
     -c, --max-coverage                maximum coverage for variant alleles (default:200)
     -b, --bf-size                     bloom filter size in GB (default:4)
+    -p, --strip-chr                   strip "chr" from sequence names (default:false)
 
 Positional arguments:
     <reference>                       reference file in FASTA format (may be gzipped)
@@ -96,6 +97,7 @@ Arguments:
      -c              maximum coverage for variant alleles (default:200)
      -b              bloom filter size in GB (default:4)
      -m              max amount of RAM in GB - KMC parameter (default:4)
+     -p              strip "chr" from sequence names (dafault:false)
 
 Positional arguments:
     <reference>     reference file in FASTA format (can be gzipped)

--- a/argument_parser.hpp
+++ b/argument_parser.hpp
@@ -40,6 +40,7 @@ static const char *USAGE_MESSAGE =
   "      -f, --freq-key                    a priori frequency key in the INFO column of the input VCF (default:AF)\n"
   "      -c, --max-coverage                maximum coverage for variant alleles (default:200)\n"
   "      -b, --bf-size                     bloom filter size in GB (default:4)\n"
+  "      -p, --strip-chr                   strip \"chr\" from sequence names (default:false)\n"
   // "      -v, --verbose                     output a detailed VCF (more information in the INFO column)\n"
   // "      -t, --threads                     number of threads (default: 1)\n"
   "\n";
@@ -52,6 +53,7 @@ static std::string samples = "-";
 static std::string freq_key = "AF";
 static uint max_coverage = 200;
 static uint64_t bf_size = ((uint64_t)0b1 << 35);
+static bool strip_chr = false;
 static bool verbose = false;
 // static size_t nThreads = 1;
 static std::string fasta_path;
@@ -59,7 +61,7 @@ static std::string vcf_path;
 static std::string kmc_sample_path;
 }
 
-static const char *shortopts = "k:r:e:s:f:c:b:h";
+static const char *shortopts = "k:r:e:s:f:c:b:hp";
 
 static const struct option longopts[] = {
     {"kmer-size", required_argument, NULL, 'k'},
@@ -69,6 +71,7 @@ static const struct option longopts[] = {
     {"samples", required_argument, NULL, 's'},
     {"max-coverage", required_argument, NULL, 'c'},
     {"bf-size", required_argument, NULL, 'b'},
+    {"strip-chr", required_argument, NULL, 'p'},
     // {"verbose", no_argument, NULL, 'v'},
     // {"threads", no_argument, NULL, 't'},
     {"help", no_argument, NULL, 'h'},
@@ -80,6 +83,9 @@ void parse_arguments(int argc, char **argv) {
        (c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1;) {
     std::istringstream arg(optarg != NULL ? optarg : "");
     switch (c) {
+    case 'p':
+      opt::strip_chr = true;
+      break;
     case 'k':
       arg >> opt::k;
       break;

--- a/main.cpp
+++ b/main.cpp
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
   int l;
   while ((l = kseq_read(reference)) >= 0) {
     std::string id = reference->name.s;
-    if(id.compare(0,3,"chr") == 0) {
+    if(id.compare(0,3,"chr") == 0 && opt::strip_chr) {
       id = id.substr(3);
     }
     std::string seq (reference->seq.s);


### PR DESCRIPTION
As suggested by #3 , add a flag to remove "chr" from sequences name.
By default the string is kept now.